### PR TITLE
bugfix/builtin_checker

### DIFF
--- a/builtin/object.go
+++ b/builtin/object.go
@@ -185,5 +185,5 @@ func jsMin(nums ...float64) float64 {
 }
 
 func now() int64 {
-	return time.Now().Unix()
+	return time.Now().UnixNano() / 1_000_000 // Millisecond
 }

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/byte-power/jsexpr/ast"
+	"github.com/byte-power/jsexpr/builtin"
 	"github.com/byte-power/jsexpr/conf"
 	"github.com/byte-power/jsexpr/file"
 	"github.com/byte-power/jsexpr/parser"
@@ -530,6 +531,11 @@ func (v *visitor) BuiltinNode(node *ast.BuiltinNode) reflect.Type {
 		return v.error(node.Arguments[1], "closure should has one input and one output param")
 
 	default:
+		// if more builtin funcs are coming in the future, or above non-JS builtins are removing
+		// these builtin funcs shall be refactored to fulfill a `Checker` interface
+		if _, ok := builtin.Funcs()[node.Name]; ok {
+			return interfaceType
+		}
 		return v.error(node, "unknown builtin %v", node.Name)
 	}
 }

--- a/expr_test.go
+++ b/expr_test.go
@@ -1347,6 +1347,11 @@ func TestBytepowerExpr(t *testing.T) {
 
 	tests := []test{
 		{
+			`Date.now() > 0`,
+			true,
+			nil,
+		},
+		{
 			`Date.now() == "test"`,
 			true,
 			bpMockEnv2{
@@ -1377,11 +1382,6 @@ func TestBytepowerExpr(t *testing.T) {
 		},
 		{
 			`Math.E < 3`,
-			true,
-			nil,
-		},
-		{
-			`Date.now() > 0`,
 			true,
 			nil,
 		},
@@ -1819,6 +1819,33 @@ func TestBytepowerBuiltinObject(t *testing.T) {
 	}
 }
 
+func TestJSArrayIndex(t *testing.T) {
+	// input := `len(["1","2"]) > index+1 ? ["1", "2"][index] : ""`
+	input := `1 || 2`
+	prg, err := jsexpr.Compile(input)
+	assert.Nil(t, err)
+
+	m := map[string]interface{}{
+		"index": 2,
+	}
+	out, err := jsexpr.Run(prg, m)
+	assert.Nil(t, err)
+	assert.Equal(t, "", out)
+}
+
 func parseTime(unixTS int64) time.Time {
 	return time.Unix(unixTS, 0)
+}
+
+func TestDateNow(t *testing.T) {
+	input := `Date.now()`
+	prg, err := jsexpr.Compile(input)
+	assert.Nil(t, err)
+
+	env := map[string]interface{}{
+		"foo": "bar",
+	}
+	out, err := jsexpr.Run(prg, env)
+	assert.Nil(t, err)
+	assert.Equal(t, "", out)
 }

--- a/expr_test.go
+++ b/expr_test.go
@@ -1849,3 +1849,23 @@ func TestDateNow(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "", out)
 }
+
+func TestParseInt(t *testing.T) {
+	input := `parseInt("11")`
+	_, err := jsexpr.Compile(input)
+	assert.Nil(t, err)
+	// tree, err := parser.Parse(input)
+	// assert.Nil(t, err)
+
+	// prg, err := compiler.Compile(tree, nil)
+	// assert.Nil(t, err)
+
+	// env := map[string]interface{}{
+	// 	"parseInt": func(a int) string {
+	// 		return "hello"
+	// 	},
+	// }
+	// out, err := jsexpr.Run(prg, env)
+	// assert.Nil(t, err)
+	// assert.Equal(t, "", out)
+}


### PR DESCRIPTION
fix checker for builtin funcs during jsexpr.Compile()
also align epoch time precision to milliseconds as javascript